### PR TITLE
일반 로그인 Refresh Token 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/develop_mouse/gummy_dang/authentication/handler/jwt/LoginSuccessHandler.java
+++ b/src/main/java/com/develop_mouse/gummy_dang/authentication/handler/jwt/LoginSuccessHandler.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.develop_mouse.gummy_dang.authentication.domain.response.LoginSuccessResponse;
 import com.develop_mouse.gummy_dang.authentication.util.JwtTokenUtil;
@@ -21,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
+@Transactional
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
@@ -45,6 +47,8 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 		String accessToken = jwtTokenProvider.generateAccessToken(genAuthentication);
 		String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+		member.updateRefreshToken(refreshToken);
 
 		response.setHeader("Authorization", accessToken);
 		response.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
- 일반 로그인 시 RefreshToken 업데이트 되지 않는 문제 발생
- 이에 따른 Transactional 추가 및 업데이트 로직 추가
- JPA 더티 체킹 사용